### PR TITLE
Fix go client to handle empty prefix

### DIFF
--- a/delta.go
+++ b/delta.go
@@ -41,7 +41,7 @@ func deltaPoint(metric metrics.Counter, name, tagStr string, ts int64, c *Wavefr
 
 	// add ∆ to prefix and remove from metric name
 	if ts == 0 {
-		return fmt.Sprintf("%s.%s.count %d %s\n", deltaPrefix+c.Prefix, prunedName, value, tagStr)
+		return fmt.Sprintf("%s%s.count %d %s\n", deltaPrefix+c.Prefix, prunedName, value, tagStr)
 	}
-	return fmt.Sprintf("%s.%s.count %d %d %s\n", deltaPrefix+c.Prefix, prunedName, value, ts, tagStr)
+	return fmt.Sprintf("%s%s.count %d %d %s\n", deltaPrefix+c.Prefix, prunedName, value, ts, tagStr)
 }

--- a/direct_test.go
+++ b/direct_test.go
@@ -74,7 +74,6 @@ func TestDeltaPoint(t *testing.T) {
 	}
 }
 
-
 func TestGaugePoint(t *testing.T) {
 	gauge := metrics.NewGauge()
 	gauge.Update(10)
@@ -84,7 +83,6 @@ func TestGaugePoint(t *testing.T) {
 		t.Error("gauges don't match", expected, point)
 	}
 }
-
 
 func TestGaugePointWithNoPrefix(t *testing.T) {
 	gauge := metrics.NewGauge()

--- a/direct_test.go
+++ b/direct_test.go
@@ -72,6 +72,25 @@ func TestDeltaPoint(t *testing.T) {
 	if !strings.HasPrefix(point, "∆") {
 		t.Error("invalid delta prefix", point)
 	}
+	expected := "∆test.prefix.foo.count 10 key1=\"val1\" key2=\"val2\""
+	if strings.TrimRight(point, "\n") != expected {
+		t.Error("counters don't match", expected, point)
+	}
+}
+
+func TestDeltaPointWithNoPrefix(t *testing.T) {
+	counter := metrics.NewCounter()
+	counter.Inc(10)
+	name := DeltaCounterName("foo")
+	point := deltaPoint(counter, name, tagStr, 0, testConfigWithNoPrefix())
+
+	if !strings.HasPrefix(point, "∆") {
+		t.Error("invalid delta prefix", point)
+	}
+	expected := "∆foo.count 10 key1=\"val1\" key2=\"val2\""
+	if strings.TrimRight(point, "\n") != expected {
+		t.Error("delta counters don't match", expected, point)
+	}
 }
 
 func TestGaugePoint(t *testing.T) {


### PR DESCRIPTION
Testing done: Was able to send points successfully with empty prefix and a valid prefix.
Modified existing unit tests based on change , Added new unit tests to cover empty prefix string.

Please review: @vikramraman @sushantdewan123 

Thank you,
Anil